### PR TITLE
Enhance the plugin with features to support TRLN Discovery, esp. hier…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Blacklight::Hierarchy
+# Blacklight::Hierarchy (TRLN Fork)
 [![Build Status](https://github.com/sul-dlss/blacklight-hierarchy/workflows/CI/badge.svg)](https://github.com/sul-dlss/blacklight-hierarchy/actions?query=branch%3Amain) [![Gem Version](https://badge.fury.io/rb/blacklight-hierarchy.svg)](http://badge.fury.io/rb/blacklight-hierarchy)
 
-This plugin provides hierarchical facets for [Blacklight](https://github.com/projectblacklight/blacklight).
+This plugin provides hierarchical facets for [Blacklight](https://github.com/projectblacklight/blacklight). This project is a fork of the original `blacklight-hierarchy` in order to add functionality important to TRLN Discovery hierarchical facets. Key customizations include: 1) ability to configure how the the hierarchy is sorted; 2) a configurable presenter to lookup labels from codes; 3) flexbox layout & improved markup; 4) closer resemblance to regular Blacklight facet links, including rel="nofollow" for bots.
 
 Please note this is does not directly follow any of the competing approaches of [Hierarchical Facets in Solr](http://wiki.apache.org/solr/HierarchicalFaceting), including Solr PivotFacets.
 
@@ -10,7 +10,7 @@ Please note this is does not directly follow any of the competing approaches of 
 Add the plugin to your Blacklight app's Gemfile.
 
 ```ruby
-gem 'blacklight-hierarchy'
+gem 'trln-blacklight-hierarchy'
 ```
 
 Index your hierarchies in a (colon-)separated list. For example, items in a "processing" queue with a "copy" action, might be indexed as:
@@ -76,6 +76,16 @@ config.facet_display = {
 In the above configuration, 'queue_status_facet' is the full Solr field name, and ':' is the delimiter within the field.  Note that suffixes ('facet' in the above example) should not contain underscores, since the methods that deal with the Solr fields and match them to the config assume the "prefix" ('queue_status' in the above example) will be everything up to the last underscore in the field name.  See the facet_tree method for further explanation and some relevant code, as well as the render_hierarchy method for relevant code.
 
 The `[nil]` value is present in support of rotatable facet hierarchies, a totally undocumented feature.
+
+With the TRLN customizations, you may optionally configure a custom facet item presenter, e.g.:
+
+```ruby
+config.facet_display = {
+  :hierarchy => {
+    'location_hierarchy' => [['f'], ':', TrlnArgon::LocationFacetItemPresenter] # values are arrays: 1st element is array, 2nd is delimiter string, 3rd is a presenter
+  }
+}
+```
 
 Facet fields should be added for each permutation of hierarchy key and term values, joined by **_**.  Or, the output of:
 

--- a/app/assets/stylesheets/blacklight/hierarchy/hierarchy.scss
+++ b/app/assets/stylesheets/blacklight/hierarchy/hierarchy.scss
@@ -5,25 +5,34 @@ $b-h-opened-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg
 
 $text-muted: #777 !default;
 
+/* TRLN CUSTOMIZATION: refactored markup & styles to use flexbox */
+
 .facet-hierarchy {
   list-style-type: none;
   padding-left: 0;
+  flex: 1 1 100%;
+  width: 100%;
 
   ul {
-    border-bottom: 0;
     list-style-type: none;
-    padding-bottom: 0;
-    padding-left: 1.3em;
+    padding-left: 0.5rem;
+    flex: 1 1 100%;
+    width: 100%;
   }
 
-  .facet_select {
-    display: inline-block;
-    margin-bottom: 6px;
-    max-width: calc(100% - 5em);
+  .facet-label {
+    flex: 1;
+  }
+
+  .facet-select {
+    flex: 1;
+    word-break: break-word;
   }
 
   .facet-count {
     float: right;
+    flex: 0 0 auto;
+    padding-left: 0.5rem;
   }
 
   .toggle-handle {
@@ -32,6 +41,8 @@ $text-muted: #777 !default;
     min-width: 1em;
     padding: 0;
     vertical-align: top;
+    display: flex;
+    align-items: flex-start;
 
     .closed,
     .opened {
@@ -69,12 +80,14 @@ $text-muted: #777 !default;
     display: inline-block;
   }
 
-  .h-leaf {
-    padding-left: 1.3em;
+  .h-node, .h-leaf {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 3px 0;
   }
 
-  .h-node {
-    cursor: pointer;
+  .h-leaf {
+    padding-left: 1.3em;
   }
 
   .remove {

--- a/app/components/blacklight/hierarchy/facet_field_component.html.erb
+++ b/app/components/blacklight/hierarchy/facet_field_component.html.erb
@@ -11,7 +11,8 @@
 
   <% unless subset.empty? %>
     <ul id="<%= ul_id %>" class="collapse" data-b-h-collapsible-target="list" role="group">
-    <% subset.keys.sort.each do |subkey| %>
+    <%# TRLN CUSTOMIZATION: let sorting be determined by the sort option in config.add_facet_field -%>
+    <% subset.keys.each do |subkey| %>
       <%= render self.class.new(field_name: field_name, tree: subset[subkey], key: subkey) %>
     <% end %>
     </ul>

--- a/app/components/blacklight/hierarchy/facet_field_list_component.html.erb
+++ b/app/components/blacklight/hierarchy/facet_field_list_component.html.erb
@@ -4,7 +4,8 @@
   <% end %>
   <% component.with_body do %>
     <ul class="facet-hierarchy" role="tree">
-      <% tree.keys.sort.collect do |key| %>
+      <%# TRLN CUSTOMIZATION: let sorting be determined by the sort option in config.add_facet_field -%>
+      <% tree.keys.collect do |key| %>
         <%= render Blacklight::Hierarchy::FacetFieldComponent.new(field_name: @facet_field.facet_field.field, tree: tree[key], key: key) %>
       <% end %>
     </ul>

--- a/app/components/blacklight/hierarchy/facet_field_list_component.rb
+++ b/app/components/blacklight/hierarchy/facet_field_list_component.rb
@@ -3,7 +3,7 @@
 module Blacklight
   module Hierarchy
     class FacetFieldListComponent < Blacklight::FacetFieldListComponent
-      DELIMETER = '_'
+      DELIMITER = '_'
 
       # @param [Blacklight::Configuration::FacetField] as defined in controller with config.add_facet_field (and with :partial => 'blacklight/hierarchy/facet_hierarchy')
       # @return [String] html for the facet tree
@@ -42,7 +42,7 @@ module Blacklight
       #  might contain values like ['LB', 'LB/2395', 'LB/2395/.C65', 'LB/2395/.C65/1991'].
       # note: the suffixes (e.g. 'ssim' for 'exploded_tag' in the above example) can't have underscores, otherwise things break.
       def prefix
-        @prefix ||= field_name.gsub("#{DELIMETER}#{field_name.split(/#{DELIMETER}/).last}", '')
+        @prefix ||= field_name.gsub("#{DELIMITER}#{field_name.split(/#{DELIMITER}/).last}", '')
       end
 
       delegate :blacklight_config, to: :helpers

--- a/app/components/blacklight/hierarchy/qfacet_value_component.html.erb
+++ b/app/components/blacklight/hierarchy/qfacet_value_component.html.erb
@@ -1,1 +1,10 @@
-<%= link_to_unless suppress_link, item.value, path_for_facet, id: id, class: 'facet_select' %> <%= render_facet_count %>
+<%# TRLN CUSTOMIZATIONS: -%>
+<%# - use label_value for the displayed value -%>
+<%# - refactor markup to resemble regular BL facets -%>
+<%# - use a flexbox layout -%>
+<%# - add rel="nofollow", eumulating regular facets -%>
+
+<span class="facet-label">
+  <%= link_to label_value, path_for_facet, id: id, class: 'facet-select', rel: 'nofollow' %>
+</span>
+<%= render_facet_count %>

--- a/app/components/blacklight/hierarchy/qfacet_value_component.rb
+++ b/app/components/blacklight/hierarchy/qfacet_value_component.rb
@@ -12,14 +12,42 @@ module Blacklight
 
       attr_reader :field_name, :item, :id, :suppress_link
 
+      # TRLN custom method to permit the facet label to come from a
+      # FacetItemPresenter instance, which we make configurable
+      def label_value
+        return item.value if facet_item_presenter_class == Blacklight::FacetItemPresenter
+        facet_item_presenter_class.new(item.qvalue, facet_config, helpers, field_name).label
+      end
+
+      # TRLN: customized this method to use a configurable FacetItemPresenter
       def path_for_facet
-        facet_config = helpers.facet_configuration_for_field(field_name)
-        Blacklight::FacetItemPresenter.new(item.qvalue, facet_config, helpers, field_name).href
+        facet_item_presenter_class.new(item.qvalue, facet_config, helpers, field_name).href
       end
 
       def render_facet_count
         classes = "facet-count"
         content_tag("span", t('blacklight.search.facets.count', number: number_with_delimiter(item.hits)), class: classes)
+      end
+
+      # TRLN custom method
+      def facet_config
+        helpers.facet_configuration_for_field(field_name)
+      end
+
+      # TRLN custom method
+      def hierarchy_config
+        helpers.blacklight_config.facet_display[:hierarchy]
+      end
+
+      # TRLN custom method emulating FacetFieldListComponent.prefix
+      # e.g., location_hierarchy instead of location_hierarchy_f
+      def field_name_prefix
+        @field_name_prefix ||= field_name.gsub("_#{field_name.split(/_/).last}", '')
+      end
+
+      # TRLN custom method: enable using a configurable custom FacetItemPresenter
+      def facet_item_presenter_class
+        hierarchy_config.dig(field_name_prefix)[2] || Blacklight::FacetItemPresenter
       end
     end
   end

--- a/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
+++ b/app/components/blacklight/hierarchy/selected_qfacet_value_component.html.erb
@@ -1,5 +1,13 @@
-<span class="selected"><%= render Blacklight::Hierarchy::QfacetValueComponent.new(field_name: field_name, item: item, suppress_link: true) %></span>
+<%# TRLN CUSTOMIZATIONS: -%>
+<%# - use label_value for the displayed value -%>
+<%# - refactor markup to resemble regular BL facets -%>
+<%# - use a flexbox layout -%>
+
+<span class="facet-label">
+  <%= content_tag :span, label_value, id: id, class: 'selected' %>
+</span>
 <%= link_to(remove_href, class: 'remove') do %>
   <span class="remove-icon" aria-hidden="true">✖</span>
   <span class="sr-only"><%= t('blacklight.search.facets.selected.remove') %></span>
 <% end %>
+<%= render_facet_count %>

--- a/app/components/blacklight/hierarchy/selected_qfacet_value_component.rb
+++ b/app/components/blacklight/hierarchy/selected_qfacet_value_component.rb
@@ -3,7 +3,9 @@
 module Blacklight
   module Hierarchy
     # Standard display of a SELECTED facet value, no link, special span with class, and 'remove' button.
-    class SelectedQfacetValueComponent < ::ViewComponent::Base
+    # TRLN CUSTOMIZATION: made this a subclass of QfacetValueComponent as part of
+    # refactor to use flexbox layout with improved markup
+    class SelectedQfacetValueComponent < QfacetValueComponent
       def initialize(field_name:, item:)
         @field_name = field_name
         @item = item

--- a/spec/features/basic_spec.rb
+++ b/spec/features/basic_spec.rb
@@ -1,131 +1,258 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-shared_examples 'catalog' do
-  context 'facet tree without repeated nodes' do
-    before do
-      solr_facet_resp = { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
-                          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
-                          'facet_counts' => {
-                            'facet_queries' => {},
-                            'facet_fields' => {
-                              'tag_facet' => [
-                                'a:b:c', 30,
-                                'a:b:d', 25,
-                                'a:c:d', 5,
-                                'p:r:q', 25,
-                                'x:y', 5,
-                                'n', 1],
-                              'my_top_facet' => [
-                                'f/g/h', 30,
-                                'j/k', 5,
-                                'z', 1]
-                            },
-                            'facet_dates' => {},
-                            'facet_ranges' => {}
-                          }
-                          }
-      rsolr_client = double('rsolr_client')
-      expect(rsolr_client).to receive(:send_and_receive).and_return solr_facet_resp
-      expect(RSolr).to receive(:connect).and_return rsolr_client
+RSpec.describe 'Basic feature specs', type: :feature do
+  let(:solr_facet_resp) do
+    { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+      'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+      'facet_counts' => {
+        'facet_queries' => {},
+        'facet_fields' => {
+          'tag_facet' => [
+            'a:b:c', 30,
+            'a:b:d', 25,
+            'a:c:d', 5,
+            'p:r:q', 25,
+            'x:y', 5,
+            'n', 1
+          ],
+          'my_top_facet' => [
+            'f/g/h', 30,
+            'j/k', 5,
+            'z', 1
+          ]
+        },
+        'facet_dates' => {},
+        'facet_ranges' => {}
+      } }
+  end
+
+  before do
+    rsolr_client = double('rsolr_client')
+    allow(rsolr_client).to receive(:send_and_receive).and_return solr_facet_resp
+    allow(RSolr).to receive(:connect).and_return rsolr_client
+  end
+
+  shared_examples 'catalog' do
+    context 'facet tree without repeated nodes' do
+      it 'should display the hierarchy' do
+        visit '/'
+        expect(page).to have_selector('li.h-node[data-controller="b-h-collapsible"]', text: 'a')
+        expect(page).to have_selector('li.h-node > ul > li.h-node[data-controller="b-h-collapsible"]', text: 'b')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'c 30')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 25')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'c')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 5')
+        expect(page).to have_selector('li.h-node', text: 'p')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'r')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'q 25')
+        expect(page).to have_selector('li.h-node', text: 'x')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'y 5')
+        expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'n 1')
+      end
+
+      it 'should properly link the hierarchy' do
+        visit '/'
+        expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['n'] }))
+        expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['a:b:c'] }))
+        expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['x:y'] }))
+      end
+
+      it 'should work with a different value delimiter' do
+        visit '/'
+        expect(page).to have_selector('li.h-node', text: 'f')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'g')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'h 30')
+        expect(page).to have_selector('li.h-node', text: 'j')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'k 5')
+        expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'z 1')
+      end
     end
 
-    it 'should display the hierarchy' do
-      visit '/'
-      expect(page).to have_selector('li.h-node[data-controller="b-h-collapsible"]', text: 'a')
-      expect(page).to have_selector('li.h-node > ul > li.h-node[data-controller="b-h-collapsible"]', text: 'b')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'c 30')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 25')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'c')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'd 5')
-      expect(page).to have_selector('li.h-node', text: 'p')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'r')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'q 25')
-      expect(page).to have_selector('li.h-node', text: 'x')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'y 5')
-      expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'n 1')
-    end
-
-    it 'should properly link the hierarchy' do
-      visit '/'
-      expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['n'] }))
-      expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['a:b:c'] }))
-      expect(page.all(:css, 'li.h-leaf a').map { |a| a[:href].to_s }).to include(root_path('f' => { 'tag_facet' => ['x:y'] }))
-    end
-
-    it 'should work with a different value delimiter' do
-      visit '/'
-      expect(page).to have_selector('li.h-node', text: 'f')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'g')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'h 30')
-      expect(page).to have_selector('li.h-node', text: 'j')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'k 5')
-      expect(page).to have_selector('.facet-hierarchy > li.h-leaf', text: 'z 1')
-    end
-  end # facet tree without repeated nodes
-
-  context 'facet tree with repeated nodes' do
-    before do
-      facet_resp = { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
-                     'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
-                     'facet_counts' => {
-                       'facet_queries' => {},
-                       'facet_fields' => {
-                         'tag_facet' => [
-                           'm:w:w:t', 15,
-                           'm:w:v:z', 10]
-                       },
-                       'facet_dates' => {},
-                       'facet_ranges' => {}
-                     }
-                    }
-      my_rsolr_client = double('rsolr_client')
-      expect(my_rsolr_client).to receive(:send_and_receive).and_return facet_resp
-      expect(RSolr).to receive(:connect).and_return my_rsolr_client
-    end
-    it 'should display all child nodes when a node value is repeated at its child level' do
-      visit '/'
-      expect(page).to have_selector('li.h-node', text: 'm')
-      expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'w')
-      expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'w')
-      expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'v')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 't 15')
-      expect(page).to have_selector('li.h-node li.h-leaf', text: 'z 10')
+    context 'facet tree with repeated nodes' do
+      let(:solr_facet_resp) do
+        { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+          'facet_counts' => {
+            'facet_queries' => {},
+            'facet_fields' => {
+              'tag_facet' => [
+                'm:w:w:t', 15,
+                'm:w:v:z', 10
+              ]
+            },
+            'facet_dates' => {},
+            'facet_ranges' => {}
+          } }
+      end
+      it 'should display all child nodes when a node value is repeated at its child level' do
+        visit '/'
+        expect(page).to have_selector('li.h-node', text: 'm')
+        expect(page).to have_selector('li.h-node > ul > li.h-node', text: 'w')
+        expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'w')
+        expect(page).to have_selector('li.h-node > ul > li.h-node > ul > li.h-node', text: 'v')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 't 15')
+        expect(page).to have_selector('li.h-node li.h-leaf', text: 'z 10')
+      end
     end
   end
-end
 
-describe 'config_1' do
-  it_behaves_like 'catalog' do
+  describe 'config_1' do
+    it_behaves_like 'catalog' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              #       'rotate' => [['tag'  ], ':'], # this would work if config.add_facet_field was called rotate_tag_facet, instead of tag_facet, I think.
+              'tag' => [['facet'], ':'], # stupidly, the facet field is expected to have an underscore followed by SOMETHING;  in this case it is "facet"
+              'my_top' => [['facet'], '/']
+            }
+          }
+        end
+      end
+    end
+  end
+
+  describe 'config_2' do
+    it_behaves_like 'catalog' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              'tag' => [['facet']], # rely on default delim
+              'my_top' => [['facet'], '/']
+            }
+          }
+        end
+      end
+    end
+  end
+
+  # TRLN CUSTOMIZATION: configurable presenter
+  describe 'configure labels via a custom FacetItemPresenter' do
     before do
+      class MyCustomFacetItemPresenter < Blacklight::FacetItemPresenter
+        def label
+          # Derive a custom label from the original value
+          value.upcase
+        end
+      end
+
       CatalogController.blacklight_config = Blacklight::Configuration.new
       CatalogController.configure_blacklight do |config|
-        config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
-        config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
+        config.add_facet_field 'tag_facet', label: 'Tag', component: Blacklight::Hierarchy::FacetFieldListComponent
         config.facet_display = {
           hierarchy: {
-            #       'rotate' => [['tag'  ], ':'], # this would work if config.add_facet_field was called rotate_tag_facet, instead of tag_facet, I think.
-            'tag'    => [['facet'], ':'], # stupidly, the facet field is expected to have an underscore followed by SOMETHING;  in this case it is "facet"
-            'my_top' => [['facet'], '/']
+            'tag' => [['facet'], ':', MyCustomFacetItemPresenter] # configure a custom presenter
           }
         }
       end
     end
-  end
-end
 
-describe 'config_2' do
-  it_behaves_like 'catalog' do
-    before do
-      CatalogController.blacklight_config = Blacklight::Configuration.new
-      CatalogController.configure_blacklight do |config|
-        config.add_facet_field 'tag_facet',    label: 'Tag',         component: Blacklight::Hierarchy::FacetFieldListComponent
-        config.add_facet_field 'my_top_facet', label: 'Slash Delim', component: Blacklight::Hierarchy::FacetFieldListComponent
-        config.facet_display = {
-          hierarchy: {
-            'tag'    => [['facet']], # rely on default delim
-            'my_top' => [['facet'], '/']
+    it 'uses custom labels for the facet items' do
+      visit '/'
+      expect(page).to have_selector('li.h-node li.h-leaf', text: 'A:B:C 30')
+      expect(page).to have_selector('li.h-node li.h-leaf', text: 'A:B:D 25')
+      expect(page).to have_selector('li.h-node li.h-leaf', text: 'A:C:D 5')
+    end
+  end
+
+  # TRLN CUSTOMIZATION: item sort
+  describe 'Item sort determined by existing add_facet_field config' do
+    context 'with alpha sort' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet', sort: 'alpha', label: 'Tag', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              'tag' => [['facet'], ':']
+            }
           }
-        }
+        end
+      end
+
+      # Note that sort: 'alpha' in the add_facet_field config will sort the facets in the response;
+      # This is the order in which they will render in the facet tree.
+      let(:solr_facet_resp) do
+        { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+          'facet_counts' => {
+            'facet_queries' => {},
+            'facet_fields' => {
+              'tag_facet' => [
+                'a', 100,
+                'a:b', 80,
+                'a:b:c', 70,
+                'a:b:d', 9,
+                'a:b:e', 1,
+                'a:f', 20,
+                'g', 200,
+                'g:h', 50,
+                'g:i', 150
+              ]
+            },
+            'facet_dates' => {},
+            'facet_ranges' => {}
+          } }
+      end
+
+      it 'sorts the facet items alphabetically' do
+        visit '/'
+        facet_text = first('.facet-hierarchy').text.squish
+        expect(facet_text).to eq('a 100 b 80 c 70 d 9 e 1 f 20 g 200 h 50 i 150')
+      end
+    end
+
+    context 'with count sort' do
+      before do
+        CatalogController.blacklight_config = Blacklight::Configuration.new
+        CatalogController.configure_blacklight do |config|
+          config.add_facet_field 'tag_facet', sort: 'count', label: 'Tag', component: Blacklight::Hierarchy::FacetFieldListComponent
+          config.facet_display = {
+            hierarchy: {
+              'tag' => [['facet'], ':']
+            }
+          }
+        end
+      end
+
+      # Note that sort: 'count' in the add_facet_field config (default) will sort the facets in the response;
+      # This is the order in which they will render in the facet tree.
+      let(:solr_facet_resp) do
+        { 'responseHeader' => { 'status' => 0, 'QTime' => 4, 'params' => { 'wt' => 'ruby', 'rows' => '0' } },
+          'response' => { 'numFound' => 30, 'start' => 0, 'maxScore' => 1.0, 'docs' => [] },
+          'facet_counts' => {
+            'facet_queries' => {},
+            'facet_fields' => {
+              'tag_facet' => [
+                'g', 200,
+                'g:i', 150,
+                'g:h', 50,
+                'a', 100,
+                'a:b', 80,
+                'a:b:c', 70,
+                'a:b:d', 9,
+                'a:b:e', 1,
+                'a:f', 20
+              ]
+            },
+            'facet_dates' => {},
+            'facet_ranges' => {}
+          } }
+      end
+
+      it 'sorts the facet items by count' do
+        visit '/'
+        facet_text = first('.facet-hierarchy').text.squish
+        expect(facet_text).to eq('g 200 i 150 h 50 a 100 b 80 c 70 d 9 e 1 f 20')
       end
     end
   end


### PR DESCRIPTION
…archical location & call number facets. Advances TD-1305.

- Enable facets to use configured sort in config.add_facet_field, e.g., count or alpha
- Add an optional config to use a custom FacetItemPresenter, e.g., for a custom lookup label
- Revise markup & styles to use flexbox for better layout and more closely resemble normal BL facets
- Add rel="nofollow" to hierarchical facets (like normal facets) for better bot control
- Ensure cursor:pointer style is not applied to non-interactive elements in the facets