### PR TITLE
Revert name in gemspec back to blacklight-hierarchy.

### DIFF
--- a/blacklight-hierarchy.gemspec
+++ b/blacklight-hierarchy.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'blacklight/hierarchy/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'trln-blacklight-hierarchy'
+  s.name        = 'blacklight-hierarchy'
   s.version     = Blacklight::Hierarchy::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Michael B. Klein']

--- a/lib/blacklight/hierarchy/version.rb
+++ b/lib/blacklight/hierarchy/version.rb
@@ -1,5 +1,5 @@
 module Blacklight
   module Hierarchy
-    VERSION = '6.3.0'.freeze
+    VERSION = '6.3.1'.freeze
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacklight-hierarchy",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "[![Build Status](https://github.com/trln/blacklight-hierarchy/workflows/CI/badge.svg)](https://github.com/trln/blacklight-hierarchy/actions?query=branch%3Amain)",
   "main": "app/assets/javascripts/blacklight/hierarchy/hierarchy.js",
   "files": [


### PR DESCRIPTION
- Trying to use trln-blacklight-hierarchy was complicating namespacing/autoloading in the host app.